### PR TITLE
Fix gem release - v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ The format is based on [Keep a Changelog][changelog], and this project adheres t
 
 * `Bundler.require` is no longer called when `ENV['APP_ENV']` is set to `production`.
 * Zeitwerk ignores specs if `ENV['APP_ENV']` is set to `production`.
-* Add `GemLookup` module definition in `lib/gem_lookup.rb` for Zeitwerk support.
+* Add `require_relative 'gem_lookup/version' to `lib/gem_lookup.rb`.
+  * Satisfies Zeitwerk's need for the `GemLookup` constant to be defined in the file.
+  * Solves a `GemLookup::Help.version` constant check, as this module had not yet been defined.
 
 ## [1.0.0] - 2021-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][changelog], and this project adheres to 
 [Semantic Versioning][semver].
 
-## [1.0.1] - Unreleased
+## [1.0.1] - 2021-07-14
 
-### Changed
+### Fixed
 
+* `Bundler.require` is no longer called when `ENV['APP_ENV']` is set to `production`.
 * Zeitwerk ignores specs if `ENV['APP_ENV']` is set to `production`.
+* Add `GemLookup` module definition in `lib/gem_lookup.rb` for Zeitwerk support.
 
 ## [1.0.0] - 2021-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][changelog], and this project adheres to 
 [Semantic Versioning][semver].
 
+## [1.0.1] - Unreleased
+
+### Changed
+
+* Zeitwerk ignores specs if `ENV['APP_ENV']` is set to `production`.
+
 ## [1.0.0] - 2021-07-14
 
 ### Added

--- a/init/bundler.rb
+++ b/init/bundler.rb
@@ -3,4 +3,4 @@
 require 'rubygems'
 require 'bundler'
 
-Bundler.require(:default, ENV['APP_ENV'].to_sym)
+Bundler.require(:default, ENV['APP_ENV'].to_sym) unless ENV['APP_ENV'] == 'production'

--- a/init/zeitwerk.rb
+++ b/init/zeitwerk.rb
@@ -8,6 +8,9 @@ root_dir = File.expand_path(File.dirname(File.dirname(__FILE__)))
 
 loader.push_dir(File.join(root_dir, 'lib'))
 
-loader.push_dir(File.join(root_dir, 'spec'))
-loader.ignore(File.join(root_dir, '**', '*_spec.rb'))
+if ENV['APP_ENV'] != 'production'
+  loader.push_dir(File.join(root_dir, 'spec'))
+  loader.ignore(File.join(root_dir, '**', '*_spec.rb'))
+end
+
 loader.setup

--- a/lib/gem_lookup.rb
+++ b/lib/gem_lookup.rb
@@ -2,5 +2,6 @@
 
 require_relative '../booster_pack'
 
-module GemLookup
-end
+# Requiring satisfies Zeitwerk's need for GemLookup to be defined in this file.
+# It also solves a GemLookup::Help.version constant check, as this had yet to be loaded.
+require_relative 'gem_lookup/version'

--- a/lib/gem_lookup.rb
+++ b/lib/gem_lookup.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
 require_relative '../booster_pack'
+
+module GemLookup
+end

--- a/lib/gem_lookup/version.rb
+++ b/lib/gem_lookup/version.rb
@@ -2,7 +2,7 @@
 
 module GemLookup
   # @return [String] the current version of the gem.
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 
   # @return [String] the name of the gem
   NAME = 'gem_lookup'


### PR DESCRIPTION
* Zeitwerk ignores specs if `ENV['APP_ENV']` is set to `production`.