### PR TITLE
Display Gem License(s) 💼 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][changelog], and this project adheres to 
 [Semantic Versioning][semver].
 
+## [1.2.0] - 2021-07-14
+
+### Added
+
+* The license(s) are now displayed as the :briefcase: / License(s).
+
 ## [1.1.0] - 2021-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ $ gems pry
 => 🔎 Looking up: pry
 => 💎 pry is at 0.14.1
 ==> 📅 April 12, 2021
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/pry
 ==> 🏠 http://pry.github.io
 ==> 🔗 https://github.com/pry/pry
@@ -81,6 +82,7 @@ $ gems --wordy pry
 => Looking up: pry
 => Gem: pry is at 0.14.1
 ==> Updated:      April 12, 2021
+==> License:      MIT
 ==> Location:     https://rubygems.org/gems/pry
 ==> Homepage:     http://pry.github.io
 ==> Source Code:  https://github.com/pry/pry
@@ -160,6 +162,7 @@ $ gems pry rspec sentry-ruby rails
 => 🔎 pry, rspec, sentry-ruby, rails
 => 💎 pry is at 0.14.1
 ==> 📅 April 12, 2021
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/pry
 ==> 🏠 http://pry.github.io
 ==> 🔗 https://github.com/pry/pry
@@ -167,25 +170,28 @@ $ gems pry rspec sentry-ruby rails
 ==> 💌 Unavailable
 => 💎 rspec is at 3.10.0
 ==> 📅 October 30, 2020
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/rspec
 ==> 🏠 http://github.com/rspec
 ==> 🔗 https://github.com/rspec/rspec
 ==> 📑 Unavailable
 ==> 💌 https://groups.google.com/forum/#!forum/rspec
-=> 💎 rails is at 6.1.4
-==> 📅 June 24, 2021
-==> 🧭 https://rubygems.org/gems/rails
-==> 🏠 https://rubyonrails.org
-==> 🔗 https://github.com/rails/rails/tree/v6.1.4
-==> 📑 https://github.com/rails/rails/releases/tag/v6.1.4
-==> 💌 https://discuss.rubyonrails.org/c/rubyonrails-talk
 => 💎 sentry-ruby is at 4.6.1
 ==> 📅 July 8, 2021
+==> 💼 Apache-2.0
 ==> 🧭 https://rubygems.org/gems/sentry-ruby
 ==> 🏠 https://github.com/getsentry/sentry-ruby
 ==> 🔗 https://github.com/getsentry/sentry-ruby
 ==> 📑 https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md
 ==> 💌 Unavailable
+=> 💎 rails is at 6.1.4
+==> 📅 June 24, 2021
+==> 💼 MIT
+==> 🧭 https://rubygems.org/gems/rails
+==> 🏠 https://rubyonrails.org
+==> 🔗 https://github.com/rails/rails/tree/v6.1.4
+==> 📑 https://github.com/rails/rails/releases/tag/v6.1.4
+==> 💌 https://discuss.rubyonrails.org/c/rubyonrails-talk
 ```
 
 #### Batch Mode
@@ -199,64 +205,25 @@ $ gems byebug pinglish rspec rubocop rubocop-rspec rubocop-rails sentry-ruby sen
 => 🤔 24 gems
 => 🧺 1 of 3
 => 🔎 byebug, pinglish, rspec, rubocop, rubocop-rspec, rubocop-rails, sentry-ruby, sentry-rails, pry, typhoeus
-=> 💎 pinglish is at 0.2.1
-==> 📅 November 13, 2014
-==> 🧭 https://rubygems.org/gems/pinglish
-==> 🏠 https://github.com/jbarnette/pinglish
-==> 🔗 Unavailable
-==> 📑 Unavailable
-==> 💌 Unavailable
-=> 💎 rubocop-rspec is at 2.4.0
-==> 📅 June 9, 2021
-==> 🧭 https://rubygems.org/gems/rubocop-rspec
-==> 🏠 https://github.com/rubocop/rubocop-rspec
-==> 🔗 Unavailable
-==> 📑 https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md
-==> 💌 Unavailable
-=> 💎 byebug is at 11.1.3
-==> 📅 April 23, 2020
-==> 🧭 https://rubygems.org/gems/byebug
-==> 🏠 https://github.com/deivid-rodriguez/byebug
-==> 🔗 https://github.com/deivid-rodriguez/byebug
-==> 📑 Unavailable
-==> 💌 Unavailable
 => 💎 rspec is at 3.10.0
 ==> 📅 October 30, 2020
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/rspec
 ==> 🏠 http://github.com/rspec
 ==> 🔗 https://github.com/rspec/rspec
 ==> 📑 Unavailable
 ==> 💌 https://groups.google.com/forum/#!forum/rspec
-=> 💎 rubocop-rails is at 2.11.3
-==> 📅 July 11, 2021
-==> 🧭 https://rubygems.org/gems/rubocop-rails
-==> 🏠 https://docs.rubocop.org/rubocop-rails/
-==> 🔗 https://github.com/rubocop/rubocop-rails/
-==> 📑 https://github.com/rubocop/rubocop-rails/blob/master/CHANGELOG.md
+=> 💎 rubocop-rspec is at 2.4.0
+==> 📅 June 9, 2021
+==> 💼 MIT
+==> 🧭 https://rubygems.org/gems/rubocop-rspec
+==> 🏠 https://github.com/rubocop/rubocop-rspec
+==> 🔗 Unavailable
+==> 📑 https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md
 ==> 💌 Unavailable
-=> 💎 sentry-ruby is at 4.6.1
-==> 📅 July 8, 2021
-==> 🧭 https://rubygems.org/gems/sentry-ruby
-==> 🏠 https://github.com/getsentry/sentry-ruby
-==> 🔗 https://github.com/getsentry/sentry-ruby
-==> 📑 https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md
-==> 💌 Unavailable
-=> 💎 pry is at 0.14.1
-==> 📅 April 12, 2021
-==> 🧭 https://rubygems.org/gems/pry
-==> 🏠 http://pry.github.io
-==> 🔗 https://github.com/pry/pry
-==> 📑 https://github.com/pry/pry/blob/master/CHANGELOG.md
-==> 💌 Unavailable
-=> 💎 typhoeus is at 1.4.0
-==> 📅 May 8, 2020
-==> 🧭 https://rubygems.org/gems/typhoeus
-==> 🏠 https://github.com/typhoeus/typhoeus
-==> 🔗 https://github.com/typhoeus/typhoeus
-==> 📑 Unavailable
-==> 💌 http://groups.google.com/group/typhoeus
 => 💎 rubocop is at 1.18.3
 ==> 📅 July 6, 2021
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/rubocop
 ==> 🏠 https://rubocop.org/
 ==> 🔗 https://github.com/rubocop/rubocop/
@@ -264,22 +231,105 @@ $ gems byebug pinglish rspec rubocop rubocop-rspec rubocop-rails sentry-ruby sen
 ==> 💌 Unavailable
 => 💎 sentry-rails is at 4.6.1
 ==> 📅 July 8, 2021
+==> 💼 Apache-2.0
 ==> 🧭 https://rubygems.org/gems/sentry-rails
 ==> 🏠 https://github.com/getsentry/sentry-ruby
 ==> 🔗 https://github.com/getsentry/sentry-ruby
 ==> 📑 https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md
 ==> 💌 Unavailable
+=> 💎 byebug is at 11.1.3
+==> 📅 April 23, 2020
+==> 💼 BSD-2-Clause
+==> 🧭 https://rubygems.org/gems/byebug
+==> 🏠 https://github.com/deivid-rodriguez/byebug
+==> 🔗 https://github.com/deivid-rodriguez/byebug
+==> 📑 Unavailable
+==> 💌 Unavailable
+=> 💎 pinglish is at 0.2.1
+==> 📅 November 13, 2014
+==> 💼 None
+==> 🧭 https://rubygems.org/gems/pinglish
+==> 🏠 https://github.com/jbarnette/pinglish
+==> 🔗 Unavailable
+==> 📑 Unavailable
+==> 💌 Unavailable
+=> 💎 sentry-ruby is at 4.6.1
+==> 📅 July 8, 2021
+==> 💼 Apache-2.0
+==> 🧭 https://rubygems.org/gems/sentry-ruby
+==> 🏠 https://github.com/getsentry/sentry-ruby
+==> 🔗 https://github.com/getsentry/sentry-ruby
+==> 📑 https://github.com/getsentry/sentry-ruby/blob/master/CHANGELOG.md
+==> 💌 Unavailable
+=> 💎 rubocop-rails is at 2.11.3
+==> 📅 July 11, 2021
+==> 💼 MIT
+==> 🧭 https://rubygems.org/gems/rubocop-rails
+==> 🏠 https://docs.rubocop.org/rubocop-rails/
+==> 🔗 https://github.com/rubocop/rubocop-rails/
+==> 📑 https://github.com/rubocop/rubocop-rails/blob/master/CHANGELOG.md
+==> 💌 Unavailable
+=> 💎 pry is at 0.14.1
+==> 📅 April 12, 2021
+==> 💼 MIT
+==> 🧭 https://rubygems.org/gems/pry
+==> 🏠 http://pry.github.io
+==> 🔗 https://github.com/pry/pry
+==> 📑 https://github.com/pry/pry/blob/master/CHANGELOG.md
+==> 💌 Unavailable
+=> 💎 typhoeus is at 1.4.0
+==> 📅 May 8, 2020
+==> 💼 MIT
+==> 🧭 https://rubygems.org/gems/typhoeus
+==> 🏠 https://github.com/typhoeus/typhoeus
+==> 🔗 https://github.com/typhoeus/typhoeus
+==> 📑 Unavailable
+==> 💌 http://groups.google.com/group/typhoeus
 => 🧺 2 of 3
 => 🔎 faraday, rails, pagy, clowne, discard, aasm, logidze, globalize, lockbox, factory_bot
 => 💎 discard is at 1.2.0
 ==> 📅 February 17, 2020
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/discard
 ==> 🏠 https://github.com/jhawthorn/discard
 ==> 🔗 Unavailable
 ==> 📑 Unavailable
 ==> 💌 Unavailable
+=> 💎 rails is at 6.1.4
+==> 📅 June 24, 2021
+==> 💼 MIT
+==> 🧭 https://rubygems.org/gems/rails
+==> 🏠 https://rubyonrails.org
+==> 🔗 https://github.com/rails/rails/tree/v6.1.4
+==> 📑 https://github.com/rails/rails/releases/tag/v6.1.4
+==> 💌 https://discuss.rubyonrails.org/c/rubyonrails-talk
+=> 💎 pagy is at 4.10.1
+==> 📅 June 24, 2021
+==> 💼 MIT
+==> 🧭 https://rubygems.org/gems/pagy
+==> 🏠 https://github.com/ddnexus/pagy
+==> 🔗 Unavailable
+==> 📑 Unavailable
+==> 💌 Unavailable
+=> 💎 clowne is at 1.3.0
+==> 📅 May 12, 2021
+==> 💼 MIT
+==> 🧭 https://rubygems.org/gems/clowne
+==> 🏠 https://clowne.evilmartians.io/
+==> 🔗 http://github.com/clowne-rb/clowne
+==> 📑 https://github.com/clowne-rb/clowne/blob/master/CHANGELOG.md
+==> 💌 Unavailable
+=> 💎 logidze is at 1.2.0
+==> 📅 June 11, 2021
+==> 💼 MIT
+==> 🧭 https://rubygems.org/gems/logidze
+==> 🏠 http://github.com/palkan/logidze
+==> 🔗 http://github.com/palkan/logidze
+==> 📑 https://github.com/palkan/logidze/blob/master/CHANGELOG.md
+==> 💌 Unavailable
 => 💎 aasm is at 5.2.0
 ==> 📅 May 1, 2021
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/aasm
 ==> 🏠 https://github.com/aasm/aasm
 ==> 🔗 https://github.com/aasm/aasm
@@ -287,55 +337,31 @@ $ gems byebug pinglish rspec rubocop rubocop-rspec rubocop-rails sentry-ruby sen
 ==> 💌 Unavailable
 => 💎 lockbox is at 0.6.5
 ==> 📅 July 7, 2021
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/lockbox
 ==> 🏠 https://github.com/ankane/lockbox
 ==> 🔗 Unavailable
 ==> 📑 Unavailable
 ==> 💌 Unavailable
-=> 💎 rails is at 6.1.4
-==> 📅 June 24, 2021
-==> 🧭 https://rubygems.org/gems/rails
-==> 🏠 https://rubyonrails.org
-==> 🔗 https://github.com/rails/rails/tree/v6.1.4
-==> 📑 https://github.com/rails/rails/releases/tag/v6.1.4
-==> 💌 https://discuss.rubyonrails.org/c/rubyonrails-talk
-=> 💎 logidze is at 1.2.0
-==> 📅 June 11, 2021
-==> 🧭 https://rubygems.org/gems/logidze
-==> 🏠 http://github.com/palkan/logidze
-==> 🔗 http://github.com/palkan/logidze
-==> 📑 https://github.com/palkan/logidze/blob/master/CHANGELOG.md
-==> 💌 Unavailable
-=> 💎 clowne is at 1.3.0
-==> 📅 May 12, 2021
-==> 🧭 https://rubygems.org/gems/clowne
-==> 🏠 https://clowne.evilmartians.io/
-==> 🔗 http://github.com/clowne-rb/clowne
-==> 📑 https://github.com/clowne-rb/clowne/blob/master/CHANGELOG.md
-==> 💌 Unavailable
-=> 💎 pagy is at 4.10.1
-==> 📅 June 24, 2021
-==> 🧭 https://rubygems.org/gems/pagy
-==> 🏠 https://github.com/ddnexus/pagy
-==> 🔗 Unavailable
-==> 📑 Unavailable
-==> 💌 Unavailable
-=> 💎 globalize is at 6.0.1
-==> 📅 June 23, 2021
-==> 🧭 https://rubygems.org/gems/globalize
-==> 🏠 http://github.com/globalize/globalize
-==> 🔗 Unavailable
-==> 📑 Unavailable
-==> 💌 Unavailable
 => 💎 factory_bot is at 6.2.0
 ==> 📅 May 7, 2021
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/factory_bot
 ==> 🏠 https://github.com/thoughtbot/factory_bot
 ==> 🔗 Unavailable
 ==> 📑 Unavailable
 ==> 💌 Unavailable
+=> 💎 globalize is at 6.0.1
+==> 📅 June 23, 2021
+==> 💼 MIT
+==> 🧭 https://rubygems.org/gems/globalize
+==> 🏠 http://github.com/globalize/globalize
+==> 🔗 Unavailable
+==> 📑 Unavailable
+==> 💌 Unavailable
 => 💎 faraday is at 1.5.1
 ==> 📅 July 11, 2021
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/faraday
 ==> 🏠 https://lostisland.github.io/faraday
 ==> 🔗 https://github.com/lostisland/faraday
@@ -343,8 +369,17 @@ $ gems byebug pinglish rspec rubocop rubocop-rspec rubocop-rails sentry-ruby sen
 ==> 💌 Unavailable
 => 🧺 3 of 3
 => 🔎 faker, site_prism, nokogiri, simplecov
+=> 💎 site_prism is at 3.7.1
+==> 📅 February 19, 2021
+==> 💼 BSD-3-Clause
+==> 🧭 https://rubygems.org/gems/site_prism
+==> 🏠 https://github.com/site-prism/site_prism
+==> 🔗 https://github.com/site-prism/site_prism
+==> 📑 https://github.com/site-prism/site_prism/blob/main/CHANGELOG.md
+==> 💌 Unavailable
 => 💎 simplecov is at 0.21.2
 ==> 📅 January 9, 2021
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/simplecov
 ==> 🏠 https://github.com/simplecov-ruby/simplecov
 ==> 🔗 https://github.com/simplecov-ruby/simplecov/tree/v0.21.2
@@ -352,6 +387,7 @@ $ gems byebug pinglish rspec rubocop rubocop-rspec rubocop-rails sentry-ruby sen
 ==> 💌 https://groups.google.com/forum/#!forum/simplecov
 => 💎 faker is at 2.18.0
 ==> 📅 May 15, 2021
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/faker
 ==> 🏠 https://github.com/faker-ruby/faker
 ==> 🔗 https://github.com/faker-ruby/faker
@@ -359,17 +395,11 @@ $ gems byebug pinglish rspec rubocop rubocop-rspec rubocop-rails sentry-ruby sen
 ==> 💌 Unavailable
 => 💎 nokogiri is at 1.11.7
 ==> 📅 June 3, 2021
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/nokogiri
 ==> 🏠 https://nokogiri.org
 ==> 🔗 https://github.com/sparklemotion/nokogiri
 ==> 📑 https://nokogiri.org/CHANGELOG.html
-==> 💌 Unavailable
-=> 💎 site_prism is at 3.7.1
-==> 📅 February 19, 2021
-==> 🧭 https://rubygems.org/gems/site_prism
-==> 🏠 https://github.com/site-prism/site_prism
-==> 🔗 https://github.com/site-prism/site_prism
-==> 📑 https://github.com/site-prism/site_prism/blob/main/CHANGELOG.md
 ==> 💌 Unavailable
 ```
 
@@ -386,6 +416,7 @@ $ gems non-existent rails
 => 💎 non-existent not found
 => 💎 rails is at 6.1.4
 ==> 📅 June 24, 2021
+==> 💼 MIT
 ==> 🧭 https://rubygems.org/gems/rails
 ==> 🏠 https://rubyonrails.org
 ==> 🔗 https://github.com/rails/rails/tree/v6.1.4

--- a/lib/gem_lookup/serializers/emoji.rb
+++ b/lib/gem_lookup/serializers/emoji.rb
@@ -53,6 +53,7 @@ module GemLookup
           [].tap do |output|
             output.push "=> 💎 #{json[:name]} is at #{json[:version]}".green
             output.push "==> 📅 #{convert_date(date: json[:version_created_at])}"
+            output.push license(licenses: json[:licenses])
             output.push "==> 🧭 #{json[:project_uri]}"
             output.push "==> 🏠 #{json[:homepage_uri]}"
             output.push source_code(source_code_uri: json[:source_code_uri])
@@ -61,6 +62,15 @@ module GemLookup
           end.join "\n"
         end
         # rubocop:enable Metrics/AbcSize
+
+        # Generates the "License(s)" string
+        # @param licenses [Array] the licenses.
+        # @return [String] the assigned license(s) string.
+        def license(licenses:)
+          return '==> 💼 None' unless licenses.any?
+
+          "==> 💼 #{licenses.join(", ")}"
+        end
 
         # Generates the "Source Code" string
         # @param source_code_uri [String] the source code uri.

--- a/lib/gem_lookup/serializers/wordy.rb
+++ b/lib/gem_lookup/serializers/wordy.rb
@@ -53,6 +53,7 @@ module GemLookup
           [].tap do |output|
             output.push "=> Gem: #{json[:name]} is at #{json[:version]}".green
             output.push "==> Updated:      #{convert_date(date: json[:version_created_at])}"
+            output.push license(licenses: json[:licenses])
             output.push "==> Location:     #{json[:project_uri]}"
             output.push "==> Homepage:     #{json[:homepage_uri]}"
             output.push source_code(source_code_uri: json[:source_code_uri])
@@ -61,6 +62,19 @@ module GemLookup
           end.join "\n"
         end
         # rubocop:enable Metrics/AbcSize
+
+        # Generates the "License(s)" string
+        # @param licenses [Array] the licenses.
+        # @return [String] the assigned license(s) string.
+        def license(licenses:)
+          return '==> License:      None' unless licenses.any?
+
+          if licenses.size == 1
+            "==> License:      #{licenses.first}"
+          else
+            "==> Licenses:     #{licenses.join(", ")}"
+          end
+        end
 
         # Generates the "Source Code" string
         # @param source_code_uri [String] the source code uri.

--- a/lib/gem_lookup/version.rb
+++ b/lib/gem_lookup/version.rb
@@ -2,7 +2,7 @@
 
 module GemLookup
   # @return [String] the current version of the gem.
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 
   # @return [String] the name of the gem
   NAME = 'gem_lookup'

--- a/spec/gem_lookup/serializers/emoji_spec.rb
+++ b/spec/gem_lookup/serializers/emoji_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe GemLookup::Serializers::Emoji do
         <<~OUTPUT.chomp
           #{"=> 💎 rails is at 6.1.3.2".green}
           ==> 📅 May 5, 2021
+          ==> 💼 MIT
           ==> 🧭 https://rubygems.org/gems/rails
           ==> 🏠 https://rubyonrails.org
           ==> 🔗 https://github.com/rails/rails/tree/v6.1.3.2
@@ -35,6 +36,7 @@ RSpec.describe GemLookup::Serializers::Emoji do
         <<~OUTPUT.chomp
           #{"=> 💎 rails is at 6.1.3.2".green}
           ==> 📅 May 5, 2021
+          ==> 💼 MIT
           ==> 🧭 https://rubygems.org/gems/rails
           ==> 🏠 https://rubyonrails.org
           #{"==> 🔗 Unavailable".light_red}
@@ -57,6 +59,7 @@ RSpec.describe GemLookup::Serializers::Emoji do
         <<~OUTPUT.chomp
           #{"=> 💎 rails is at 6.1.3.2".green}
           ==> 📅 May 5, 2021
+          ==> 💼 MIT
           ==> 🧭 https://rubygems.org/gems/rails
           ==> 🏠 https://rubyonrails.org
           #{"==> 🔗 Unavailable".light_red}
@@ -79,6 +82,7 @@ RSpec.describe GemLookup::Serializers::Emoji do
         <<~OUTPUT.chomp
           #{"=> 💎 rails is at 6.1.3.2".green}
           ==> 📅 May 5, 2021
+          ==> 💼 MIT
           ==> 🧭 https://rubygems.org/gems/rails
           ==> 🏠 https://rubyonrails.org
           ==> 🔗 https://github.com/rails/rails/tree/v6.1.3.2
@@ -101,6 +105,7 @@ RSpec.describe GemLookup::Serializers::Emoji do
         <<~OUTPUT.chomp
           #{"=> 💎 rails is at 6.1.3.2".green}
           ==> 📅 May 5, 2021
+          ==> 💼 MIT
           ==> 🧭 https://rubygems.org/gems/rails
           ==> 🏠 https://rubyonrails.org
           ==> 🔗 https://github.com/rails/rails/tree/v6.1.3.2
@@ -123,6 +128,7 @@ RSpec.describe GemLookup::Serializers::Emoji do
         <<~OUTPUT.chomp
           #{"=> 💎 rails is at 6.1.3.2".green}
           ==> 📅 May 5, 2021
+          ==> 💼 MIT
           ==> 🧭 https://rubygems.org/gems/rails
           ==> 🏠 https://rubyonrails.org
           ==> 🔗 https://github.com/rails/rails/tree/v6.1.3.2
@@ -145,6 +151,7 @@ RSpec.describe GemLookup::Serializers::Emoji do
         <<~OUTPUT.chomp
           #{"=> 💎 rails is at 6.1.3.2".green}
           ==> 📅 May 5, 2021
+          ==> 💼 MIT
           ==> 🧭 https://rubygems.org/gems/rails
           ==> 🏠 https://rubyonrails.org
           ==> 🔗 https://github.com/rails/rails/tree/v6.1.3.2

--- a/spec/gem_lookup/serializers/wordy_spec.rb
+++ b/spec/gem_lookup/serializers/wordy_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe GemLookup::Serializers::Wordy do
         <<~OUTPUT.chomp
           #{"=> Gem: rails is at 6.1.3.2".green}
           ==> Updated:      May 5, 2021
+          ==> License:      MIT
           ==> Location:     https://rubygems.org/gems/rails
           ==> Homepage:     https://rubyonrails.org
           ==> Source Code:  https://github.com/rails/rails/tree/v6.1.3.2
@@ -35,6 +36,7 @@ RSpec.describe GemLookup::Serializers::Wordy do
         <<~OUTPUT.chomp
           #{"=> Gem: rails is at 6.1.3.2".green}
           ==> Updated:      May 5, 2021
+          ==> License:      MIT
           ==> Location:     https://rubygems.org/gems/rails
           ==> Homepage:     https://rubyonrails.org
           #{"==> Source Code:  Unavailable".light_red}
@@ -57,6 +59,7 @@ RSpec.describe GemLookup::Serializers::Wordy do
         <<~OUTPUT.chomp
           #{"=> Gem: rails is at 6.1.3.2".green}
           ==> Updated:      May 5, 2021
+          ==> License:      MIT
           ==> Location:     https://rubygems.org/gems/rails
           ==> Homepage:     https://rubyonrails.org
           #{"==> Source Code:  Unavailable".light_red}
@@ -79,6 +82,7 @@ RSpec.describe GemLookup::Serializers::Wordy do
         <<~OUTPUT.chomp
           #{"=> Gem: rails is at 6.1.3.2".green}
           ==> Updated:      May 5, 2021
+          ==> License:      MIT
           ==> Location:     https://rubygems.org/gems/rails
           ==> Homepage:     https://rubyonrails.org
           ==> Source Code:  https://github.com/rails/rails/tree/v6.1.3.2
@@ -101,6 +105,7 @@ RSpec.describe GemLookup::Serializers::Wordy do
         <<~OUTPUT.chomp
           #{"=> Gem: rails is at 6.1.3.2".green}
           ==> Updated:      May 5, 2021
+          ==> License:      MIT
           ==> Location:     https://rubygems.org/gems/rails
           ==> Homepage:     https://rubyonrails.org
           ==> Source Code:  https://github.com/rails/rails/tree/v6.1.3.2
@@ -123,6 +128,7 @@ RSpec.describe GemLookup::Serializers::Wordy do
         <<~OUTPUT.chomp
           #{"=> Gem: rails is at 6.1.3.2".green}
           ==> Updated:      May 5, 2021
+          ==> License:      MIT
           ==> Location:     https://rubygems.org/gems/rails
           ==> Homepage:     https://rubyonrails.org
           ==> Source Code:  https://github.com/rails/rails/tree/v6.1.3.2
@@ -145,6 +151,7 @@ RSpec.describe GemLookup::Serializers::Wordy do
         <<~OUTPUT.chomp
           #{"=> Gem: rails is at 6.1.3.2".green}
           ==> Updated:      May 5, 2021
+          ==> License:      MIT
           ==> Location:     https://rubygems.org/gems/rails
           ==> Homepage:     https://rubyonrails.org
           ==> Source Code:  https://github.com/rails/rails/tree/v6.1.3.2


### PR DESCRIPTION
The license(s) are now displayed as the 💼  / License(s).

Closes #13 